### PR TITLE
Create ADC middleware and node type for ADC middleware

### DIFF
--- a/src/middleware/adc_middleware/include/MID_ADC.h
+++ b/src/middleware/adc_middleware/include/MID_ADC.h
@@ -1,0 +1,63 @@
+/**
+*   @file    ADC_MiddleWare.h
+*
+*   @version 1.0.0
+*
+*   @addtogroup ADC
+*   @{
+*/
+#ifndef __ADC_MIDDLEWARE_H__
+#define __ADC_MIDDLEWARE_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+*                                        INCLUDE FILES
+* 1) system and project includes
+* 2) needed interfaces from external units
+* 3) internal and external interfaces from this unit
+==================================================================================================*/
+#include <stdint.h>
+#include "types_common.h"
+#include "Driver_Header.h"
+
+/*==================================================================================================
+*                                             ENUMS
+==================================================================================================*/
+typedef void (*ADC_Middleware_Callback)(uint16_t data); /* Definition of ADC call back */
+
+typedef enum{
+    ADC_MIDDLEWARE_RETURN_CODE_ERROR     = 0u,
+    ADC_MIDDLEWARE_RETURN_CODE_SUCCESSED = 1u
+}MID_ADC_ReturnCode_type;
+
+typedef struct MID_ADC_ConfigStruct_type
+{
+    ADC_Type *adcHwUnitId;
+    ADC_Channel_type channel;
+    ADC_Middleware_Callback callback;
+    Node_Config_Data_Struct_type *nodeConfigPtr;
+} MID_ADC_ConfigStruct_type;
+
+/*==================================================================================================
+                                 STRUCTURES AND OTHER TYPEDEFS
+==================================================================================================*/
+
+/*==================================================================================================
+                                 GLOBAL VARIABLE DECLARATIONS
+==================================================================================================*/
+
+/*==================================================================================================
+                                     FUNCTION PROTOTYPES
+==================================================================================================*/
+MID_ADC_ReturnCode_type MID_ADC_Init(MID_ADC_ConfigStruct_type *adcConfig);
+
+uint16_t MID_ADC_ReadData(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ADC_MIDDLEWARE_H__ */

--- a/src/middleware/adc_middleware/src/MID_ADC.c
+++ b/src/middleware/adc_middleware/src/MID_ADC.c
@@ -1,0 +1,176 @@
+/**
+*   @file    ADC_MiddleWare.c
+*
+*   @version 1.0.0
+*
+*   @addtogroup ADC
+*   @{
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================================================================================================
+*                                        INCLUDE FILES
+* 1) system and project includes
+* 2) needed interfaces from external units
+* 3) internal and external interfaces from this unit
+==================================================================================================*/
+#include "MID_ADC.h"
+
+/*==================================================================================================
+*                          LOCAL TYPEDEFS (STRUCTURES, UNIONS, ENUMS)
+==================================================================================================*/
+
+/*==================================================================================================
+*                                       LOCAL MACROS
+==================================================================================================*/
+#define MAX_TEMPERATURE      (50U)
+#define MAX_SPEED            (240U)
+#define MAX_MV_OUT           (4096U)
+
+
+/*==================================================================================================
+*                                      LOCAL CONSTANTS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                      LOCAL VARIABLES
+==================================================================================================*/
+
+static ADC_Middleware_Callback s_adcMiddlewareCallback = NULL;
+static volatile uint16_t s_lastReadData = 0;
+static volatile uint16_t s_lastValidData = 0;
+static Node_Config_Data_Struct_t *s_nodeConfigPtr = NULL;
+
+/*==================================================================================================
+*                                      GLOBAL CONSTANTS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                      GLOBAL VARIABLES
+==================================================================================================*/
+
+/*==================================================================================================
+*                                   LOCAL FUNCTION PROTOTYPES
+==================================================================================================*/
+
+static uint16_t MID_ADC_ConvertData(uint32_t dataOrigin);
+static bool MID_ADC_ValidateDataStep(uint16_t dataConverted);
+static void DRV_ADC_Driver_CallBack(uint16_t dataOrigin);
+
+/*==================================================================================================
+*                                       LOCAL FUNCTIONS
+==================================================================================================*/
+
+/**
+* @brief
+* @details       This function will convert data origin to current data type (speed or temperature)
+*
+* @param[in]     uint8_t Data_origin
+* @retval        data (which had been converted to speed or temperature)
+*
+* @api
+*/
+static uint16_t MID_ADC_ConvertData(uint32_t dataOrigin)
+{
+    uint16_t data = 0;
+
+    if(NODE_TYPE_SPEEED == s_nodeConfigPtr->nodeType)
+    {
+        data = (uint16_t)((dataOrigin * MAX_SPEED) / MAX_MV_OUT);
+    }
+    else if(NODE_TYPE_TEMPERATURE == s_nodeConfigPtr->nodeType)
+    {
+        data = (uint16_t)((dataOrigin * MAX_TEMPERATURE) / MAX_MV_OUT);
+    }
+    else
+    {
+        /* Do nothing */
+    }
+    s_lastReadData = data;
+
+    return data;
+}
+
+/**
+* @brief
+* @details        This function will compare new valid data with threshold value
+*
+* @param[in]      uint16_t Data_converted
+* @return         void.
+*
+* @api
+*/
+static bool MID_ADC_ValidateDataStep(uint16_t dataConverted)
+{
+    bool retVal = false;
+    uint16_t step = 0;
+
+    step = (dataConverted > s_lastValidData) ? (dataConverted - s_lastValidData) : (s_lastValidData - dataConverted);
+    if (step > s_nodeConfigPtr->threshold)
+    {
+        retVal = true;
+        s_lastValidData = dataConverted;
+    }
+
+    return retVal;
+}
+
+static void DRV_ADC_Driver_CallBack(uint16_t dataOrigin)
+{
+    uint16_t dataConverted = 0;
+
+    dataConverted = MID_ADC_ConvertData((uint32_t)dataOrigin);
+    if (MID_ADC_ValidateDataStep(dataConverted))
+    {
+        if (s_adcMiddlewareCallback != NULL)
+        {
+            s_adcMiddlewareCallback(dataConverted);
+        }
+    }
+    else
+    {
+        /* Do nothing */
+    }
+}
+
+/*==================================================================================================
+                                       GLOBAL FUNCTIONS
+==================================================================================================*/
+/**
+* @brief
+* @details        This function will support to init some information for ADC hardware
+*                 to send
+*
+* @param[in]      PushEvent CallBackEventFunction: notification call back for application
+* @return         E_OK.
+*                 E_NOT_OK
+*
+* @api
+*/
+MID_ADC_ReturnCode_type MID_ADC_Init(MID_ADC_ConfigStruct_type *adcConfig)
+{
+    MID_ADC_ReturnCode_type retVal = ADC_MIDDLEWARE_RETURN_CODE_ERROR;
+
+    s_adcMiddlewareCallback = adcConfig->callback;
+    s_nodeConfigPtr = adcConfig->nodeConfigPtr;
+
+    if(ADC_DRIVER_RETURN_CODE_SUCCESSED == DRV_ADC_Init(adcConfig->adcHwUnitId, adcConfig->channel, DRV_ADC_Driver_CallBack))
+    {
+        DRV_ADC_EnableIRQ(adcConfig->adcHwUnitId, adcConfig->channel);
+        retVal = ADC_MIDDLEWARE_RETURN_CODE_SUCCESSED;
+    }
+
+    return retVal;
+}
+
+uint16_t MID_ADC_ReadData(void)
+{
+    return s_lastReadData;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/types_common/types_common.h
+++ b/src/types_common/types_common.h
@@ -1,0 +1,33 @@
+#ifndef __TYPE_COMMON_H__
+#define __TYPE_COMMON_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "S32K144.h"
+
+/* ========================================= TYPEDEF ============================================= */
+/* <NODE APP> */
+typedef struct Node_Config_Data_Struct_t
+{
+    //uint8_t nodeID;        /* Node ID field */
+    uint8_t nodeType;        /* Node type field */
+    uint8_t threshold;       /* ADC Threshold */
+} Node_Config_Data_Struct_type;
+
+typedef enum Node_Type_t
+{
+    NODE_TYPE_SPEEED      = 0u,
+    NODE_TYPE_TEMPERATURE = 1u,
+    //NODE_TYPE_FORWARDER   = 2u      if need
+} Node_Type_type;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TYPE_COMMON_H__ */


### PR DESCRIPTION
Threshold được truyền từ Node config type, nếu qua threshold thì mới thành valid data (qua hàm validate data step)
Và ADC driver đang dùng module PDB để delay 1s convert 1 lần, nếu muốn sửa thì hãy xem công thức tao có để đấy. Hoặc nếu muốn dùng timer để trigger thì comment lại cái hàm DRV_PDB_ModuleConfig